### PR TITLE
- Fix support for apache2 running as non-root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ deploy-service: build-nr build-service
 	chmod +x $(SERVICE_DIR)/stop_service
 	$(TPAGE) --define m5nr_dir=$(SERVICE_DIR)/api --define m5nr_api_port=$(SERVICE_PORT) config/apache.conf.tt > $(BUILDROOT)/etc/apache2/sites-available/default
 	$(TPAGE) --define m5nr_dir=$(SERVICE_DIR)/api --define m5nr_api_port=$(SERVICE_PORT) config/httpd.conf.tt > $(SERVICE_DIR)/conf/httpd.conf
+	$(TPAGE) --define m5nr_dir=$(SERVICE_DIR)/api --define m5nr_api_port=$(SERVICE_PORT) config/apache2.conf.tt > $(SERVICE_DIR)/apache2.conf
 	@echo "restarting apache ..."
 	chmod +x $(SERVICE_DIR)/start_service
 	$(SERVICE_DIR)/stop_service || echo "Ignore"

--- a/config/apache2.conf.tt
+++ b/config/apache2.conf.tt
@@ -1,0 +1,41 @@
+Listen [% m5nr_api_port %]
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule mime_magic_module modules/mod_mime_magic.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule mpm_event_module modules/mod_mpm_event.so
+MIMEMagicFile conf/magic
+TypesConfig /etc/mime.types
+ServerName localhost
+CustomLog logs/access.log combined
+PidFile logs/httpd.pid
+
+
+<VirtualHost *:[% m5nr_api_port %]>
+	ServerAdmin webmaster@localhost
+
+	<Files ~ "\.(pl|cgi)$">
+        	Options +ExecCGI
+	</Files>
+
+        DocumentRoot [% m5nr_dir %]
+	<Directory />
+		Options FollowSymLinks
+		AllowOverride None
+	</Directory>
+
+        ScriptAlias /cgi-bin/ [% m5nr_dir %]
+        <Directory "[% m5nr_dir %]">
+		AllowOverride None
+		Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+		AddHandler cgi-script .pl .cgi
+		Order allow,deny
+		Allow from all
+	</Directory>
+
+	ErrorLog logs/error.log
+	LogLevel warn
+</VirtualHost>

--- a/service/start_service.tt
+++ b/service/start_service.tt
@@ -12,7 +12,6 @@ else
   [ ! -e ${DIR}/conf/magic ] && [ -e /etc/httpd/conf/magic ] && ln -s /etc/httpd/conf/magic ${DIR}/conf/magic
   [ ! -e ${DIR}/conf/magic ] && [ -e /etc/apache2/magic ] && ln -s /etc/apache2/magic ${DIR}/conf/magic
   [ ! -e ${DIR}/logs ] && mkdir ${DIR}/logs
-  [ ! -e ${DIR}/apache2.conf ] && [ -e /etc/apache2 ] && (grep -v mod_log_config ${DIR}/conf/httpd.conf > ${DIR}/apache2.conf )
   export APACHE_CONFDIR=$DIR
   export APACHE_ULIMIT_MAX_FILES="true"
   /usr/sbin/apachectl -d $DIR -k start


### PR DESCRIPTION
This allows starting the service as non-root on a system with apache2.  I've only tested this with Ubuntu 14.04.
